### PR TITLE
fix the problem of pod webshell connection.

### DIFF
--- a/controller/pod.go
+++ b/controller/pod.go
@@ -5,6 +5,7 @@ import (
 	"github.com/noovertime7/kubemanage/dto"
 	"github.com/noovertime7/kubemanage/middleware"
 	"github.com/noovertime7/kubemanage/pkg/core/kubemanage/v1/kube"
+	"github.com/noovertime7/kubemanage/service"
 	"github.com/wonderivan/logger"
 	_ "k8s.io/api/core/v1"
 )
@@ -21,6 +22,8 @@ func PodRegister(router *gin.RouterGroup) {
 	router.GET("/container", Pod.GetPodContainer)
 	router.GET("/log", Pod.GetPodLog)
 	router.GET("/numnp", Pod.GetPodNumPreNp)
+	router.GET("/webshell", Pod.podWebshell)
+
 }
 
 // GetPods 获取pod，支持分页过滤排序
@@ -208,4 +211,8 @@ func (p *pod) GetPodNumPreNp(ctx *gin.Context) {
 		return
 	}
 	middleware.ResponseSuccess(ctx, data)
+}
+
+func (p *pod) podWebshell(ctx *gin.Context) {
+	service.Terminal.WsHandler(ctx.Writer, ctx.Request)
 }

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -13,9 +13,16 @@ func JWTAuth() gin.HandlerFunc {
 			context.Next()
 			return
 		}
-		// 处理验证逻辑
+
+		//1、http请求从header中获取token
+		//2、webservice请求从Sec-WebSocket-Protocol获取token
 		token := context.Request.Header.Get("token")
-		if token == "" {
+		if len(token) == 0 {
+			token = context.Request.Header.Get("Sec-WebSocket-Protocol")
+		}
+
+		// 处理验证逻辑
+		if len(token) == 0 {
 			ResponseError(context, 11000, errors.New("请求未携带token,无权限访问"))
 			context.Abort()
 			return

--- a/pkg/core/kubemanage/v1/kube/init.go
+++ b/pkg/core/kubemanage/v1/kube/init.go
@@ -15,6 +15,7 @@ var K8s k8s
 
 type k8s struct {
 	ClientSet *kubernetes.Clientset
+	Config    *rest.Config
 }
 
 func (k *k8s) Init() error {
@@ -38,12 +39,14 @@ func (k *k8s) Init() error {
 	}
 
 	// 创建 clientSet
+	config.Insecure = true
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
 	}
 	logger.Info("获取clientSet成功")
 	k.ClientSet = clientSet
+	k.Config = config
 	return nil
 }
 


### PR DESCRIPTION
目前连接到pod终端并不可用。以下是修正后结果。
![image](https://user-images.githubusercontent.com/48158827/207299222-294d404d-0333-429c-895c-d2da3d3e48ba.png)

本次修改涉及到前后端，主要修改点：
（1）在webservice的请求头中增加Sec-WebSocket-Protocol，用以保存token
（2）在jwt校验中取得token并检查
（3）增加/api/k8s/pod/webshell的路由处理
